### PR TITLE
fix: #4 エクスポートされるJSONをフォーマットしない

### DIFF
--- a/src/db/localStorage.ts
+++ b/src/db/localStorage.ts
@@ -134,7 +134,7 @@ export async function listTodosLocal(filters?: {
 
 export async function exportDatabaseLocal(): Promise<string> {
   loadFromStorage();
-  return JSON.stringify({ todos: storage.todos, version: 1 }, null, 2);
+  return JSON.stringify({ todos: storage.todos, version: 1 });
 }
 
 export async function importDatabaseLocal(jsonData: string, mode: 'merge' | 'replace' = 'merge'): Promise<void> {


### PR DESCRIPTION
- JSON.stringifyの第3引数を削除してインデントなしに変更
- ファイルサイズを削減し、プログラムでの処理を効率化