### PR TITLE
fix: #5 カレンダーと矢印アイコンにポインターカーソルを設定

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -118,6 +118,7 @@
 .select-icon {
   font-size: 0.75rem;
   color: #64748b;
+  cursor: pointer;
 }
 
 .select-content {
@@ -241,6 +242,7 @@
   background-color: #f1f5f9;
   border-radius: 0.25rem;
   color: #475569;
+  cursor: pointer;
 }
 
 .due-date.overdue {


### PR DESCRIPTION
- due-dateクラス（カレンダーアイコン）にcursor: pointerを追加
- select-iconクラス（矢印アイコン）にcursor: pointerを追加